### PR TITLE
Django instrument middleware location is configurable via django settings

### DIFF
--- a/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
+++ b/instrumentation/opentelemetry-instrumentation-django/src/opentelemetry/instrumentation/django/__init__.py
@@ -388,10 +388,11 @@ class DjangoInstrumentor(BaseInstrumentor):
 
         is_sql_commentor_enabled = kwargs.pop("is_sql_commentor_enabled", None)
 
+        opentelemetry_middleware_index = getattr(settings, 'OTEL_MIDDLEWARE_INDEX', 0)
         if is_sql_commentor_enabled:
-            settings_middleware.insert(0, self._sql_commenter_middleware)
+            settings_middleware.insert(opentelemetry_middleware_index, self._sql_commenter_middleware)
 
-        settings_middleware.insert(0, self._opentelemetry_middleware)
+        settings_middleware.insert(opentelemetry_middleware_index, self._opentelemetry_middleware)
 
         setattr(settings, _middleware_setting, settings_middleware)
 


### PR DESCRIPTION
# Description
The Django instrumentation middleware is being added at the first place right now and uses request.build_absolute_uri which internally calls get_host which validates if the host is from allowed hosts or not. As a result, users are facing issues in requests where they don't want this validation. In this PR, We allow users to configure where they can place otel middleware.

Fixes # (issue)
https://github.com/open-telemetry/opentelemetry-python-contrib/issues/1781

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

At this point in time, it's not yet tested. I want to understand first if this is even the right approach before doing further work on this PR. If it is, I will go ahead and do additional work


# Does This PR Require a Core Repo Change?
- [X] No.

# Checklist (Yet to do):

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
